### PR TITLE
Adding a dev hash WIP DO NOT MERGE

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: brave
-version: v0.18.36dev
+version: v0.55.22dev
 summary: Browse faster and safer with Brave.
 description: |
  The new Brave browser automatically blocks ads and trackers, making it
@@ -12,11 +12,11 @@ confinement: strict
 parts:
   brave:
     plugin: dump
-    source: https://github.com/brave/browser-laptop/releases/download/v0.18.36dev/brave_0.18.36_amd64.deb
+    source: https://github.com/brave/brave-browser/releases/download/v0.55.22/brave-browser_0.55.22_amd64.deb
     source-type: deb
     # Correct path to icon.
-    prepare: |
-      sed -i 's|Icon=brave|Icon=/usr/share/pixmaps/brave\.png|g' usr/share/applications/brave.desktop
+    #    prepare: |
+    #  sed -i 's|Icon=brave|Icon=/usr/share/pixmaps/brave\.png|g' usr/share/applications/brave.desktop
     after:
       - desktop-gtk2
     stage-packages:


### PR DESCRIPTION
I would like to help out building a new snap for the dev version of brave. I am currently getting the error
```
Pulling brave 
Downloading 'brave-browser_0.55.22_amd64.deb'[=====================================================] 100%
Building brave 
Failed to copy '/root/build_brave/parts/brave/build/usr/bin/brave-browser': it's a symlink pointing outside the snap.
Fix it to be valid when snapped and try again.
Error: not found
Stopping local:snapcraft-subtly-funny-goose
An error occurred when trying to copy files using 'lxd': returned exit code 1.
vagrant@ubuntu-bionic:/work/brave$ g

```